### PR TITLE
Replace link tags with style

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,16 +18,12 @@ interface Config {
 }
 
 export default class Plugin
-{
-  static addStyle(html: string, style: string) {
-    return html.replace('</head>', `<style>${style}</style></head>`);
-  }
-
-  static removeLinkTag(html: string, cssFileName: string) {
+{ 
+  static replaceLinkWithStyle(html: string, style: string, cssFileName: string) {
     return html.replace(
       new RegExp(`<link[^>]+href=['"]${cssFileName}['"][^>]+(>|\/>|><\/link>)`),
-      '',
-    );
+      `<style>${style}</style>`
+      );
   }
 
   private config: Config;
@@ -71,8 +67,7 @@ export default class Plugin
       let html = this.html[htmlFileName];
 
       Object.keys(this.css).forEach((key) => {
-        html = Plugin.addStyle(html, this.css[key]);
-        html = Plugin.removeLinkTag(html, publicPath + key);
+        html = Plugin.replaceLinkWithStyle(html, this.css[key], publicPath + key);
       });
 
       assets[htmlFileName] = {


### PR DESCRIPTION
Currently this plugin removes the `<link>` tag then appends the inlined styles to the end of `<head>`. Since css precedence matters, we want to ensure the order of included CSS is the same. By replacing the `<link>` in place with the inlined styles this can be achieved.

For example, given:

    <head>
        <!-- ... -->
        <link href="first.css">
        <link href="second.css">
        <link href="third.css">
    </head>

If we only want to inline second.css, currently the plugin will result in:

    <head>
        <!-- ... -->
        <link href="first.css">
        <link href="third.css">
        <style>/* inlined second.css */</style>
    </head>

But with this change will be as expected:

    <head>
        <!-- ... -->
        <link href="first.css">
        <style>/* inlined second.css */</style>
        <link href="third.css">
    </head>
